### PR TITLE
(#418) Importing transactions does not update undo stack in Qt UI

### DIFF
--- a/core/gui/main_window.py
+++ b/core/gui/main_window.py
@@ -679,4 +679,4 @@ class MainWindow(Repeater, GUIObject):
         self._close_irrelevant_account_panes() # after an auto-clean
         self.view.refresh_undo_actions()
 
-    transaction_imported = _undo_stack_changed
+    transactions_imported = _undo_stack_changed


### PR DESCRIPTION
I noticed that the ``transaction_imported`` callback (is that what this
is?) didn't match the message name (correct usage?) of
``'transactions_imported'``.

Right?  I'm not 100% on this, but making the two align seems to fix the
issue and all tests pass.