### PR TITLE
fix #442: Amounts of different currencies can't be compared

### DIFF
--- a/core/loader/base.py
+++ b/core/loader/base.py
@@ -17,7 +17,7 @@ from hscommon.util import nonone, flatten, stripfalse, dedupe
 
 from ..exception import FileFormatError
 from ..model.account import Account, Group, AccountList, GroupList, AccountType
-from ..model.amount import parse_amount
+from ..model.amount import parse_amount, of_currency
 from ..model.budget import Budget
 from ..model.oven import Oven
 from ..model.recurrence import Recurrence, Spawn
@@ -247,7 +247,10 @@ class Loader:
                 memo = nonone(split_info.memo, '')
                 split = Split(transaction, account, amount)
                 split.memo = memo
-                if split_info.reconciliation_date is not None:
+                if account is None or not of_currency(amount, account.currency):
+                    # fix #442: off-currency transactions shouldn't be reconciled
+                    split.reconciliation_date = None
+                elif split_info.reconciliation_date is not None:
                     split.reconciliation_date = split_info.reconciliation_date
                 elif split_info.reconciled: # legacy
                     split.reconciliation_date = transaction.date

--- a/core/tests/load_test.py
+++ b/core/tests/load_test.py
@@ -520,7 +520,7 @@ class TestLoadOffCurrencyReconciliations:
 
     @with_app(do_setup)
     def test_attributes(self, app):
-        # off-currency reconciled splits are un-reconciled at load
+        # issue #442 off-currency reconciled splits should be un-reconciled at load
         eq_(app.etable[1].description, 'Money going out')
         eq_(app.etable[1].reconciliation_date, '')
         eq_(app.etable[3].description, 'Money going nowhere')

--- a/core/tests/load_test.py
+++ b/core/tests/load_test.py
@@ -507,3 +507,21 @@ def test_save_load_qif(tmpdir):
     # Splits with null amount are saved/loaded
     app = app_split_with_null_amount()
     check(app)
+
+class TestLoadOffCurrencyReconciliations:
+    def do_setup(self, monkeypatch):
+        monkeypatch.patch_today(2015, 10, 26) # so that the entries are shown
+        app = TestApp()
+        app.doc.load_from_xml(testdata.filepath('moneyguru', 'off_currency_reconciliations.moneyguru'))
+        app.show_nwview()
+        app.bsheet.selected = app.bsheet.assets[0]
+        app.show_account()
+        return app
+
+    @with_app(do_setup)
+    def test_attributes(self, app):
+        # off-currency reconciled splits are un-reconciled at load
+        eq_(app.etable[1].description, 'Money going out')
+        eq_(app.etable[1].reconciliation_date, '')
+        eq_(app.etable[3].description, 'Money going nowhere')
+        eq_(app.etable[3].reconciliation_date, '26/10/2015')

--- a/core/tests/testdata/moneyguru/off_currency_reconciliations.moneyguru
+++ b/core/tests/testdata/moneyguru/off_currency_reconciliations.moneyguru
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<moneyguru-file document_id="88bd54affa52423881525e8168b6ce1a">
+    <properties ahead_months="3" default_currency="USD" first_weekday="0" year_start_month="1" />
+    <account currency="USD" name="Account1" type="asset" />
+    <account currency="USD" name="Line1" type="expense" />
+    <transaction date="2015-10-26" description="Other money going out" mtime="1445929805">
+	<split account="Account1" amount="USD -15.00" />
+	<split account="Line1" amount="USD 15.00" />
+    </transaction>
+    <transaction date="2015-10-26" description="Money going out" mtime="1445929859">
+	<split account="Account1" amount="EUR -10.00" reconciliation_date="2015-10-26" />
+	<split account="Line1" amount="EUR 10.00" />
+    </transaction>
+    <transaction date="2015-10-26" description="Money coming in" mtime="1445922340">
+	<split account="Account1" amount="USD 10.00" />
+	<split account="Line1" amount="USD -10.00" />
+    </transaction>
+    <transaction date="2015-10-26" description="Money going nowhere" mtime="1446167581">
+	<split account="Account1" amount="EUR 0.00" reconciliation_date="2015-10-26" />
+	<split account="Line1" amount="EUR 0.00" />
+    </transaction>
+</moneyguru-file>


### PR DESCRIPTION
Analysis: This error comes from loading older (or hand-edited) files that contain reconciled splits whose amount currency doesn't match their account's currency.  The current versions of MoneyGuru do a good job of preventing users from reconciling such off-currency splits, and also prevents changing an account's currency if doing so would produce off-currency reconciliations, so we believe this problem presents only in files created with older versions.

Fix: When loading saved data, we look for off-currency splits and ignore any saved reconciliation state.  While this produces an in-memory image that differs from the saved state, we don't mark the loaded file as dirty, because the dirty state implies that closing without save and then re-opening the original file would produce a different state, and it won't in this case.  The on-disk reconciliation data is considered to be invalid, and (as of this fix) can never be loaded.

Additional:
1. Any splits that do not have an account but are marked reconciled are also caught by this fix.  We have no evidence that there are files with such splits; there certainly shouldn't be!
2. The currency of splits with a 0 amount is irrelevant, and a reconciled 0 split with an explicit currency that doesn't match the account remains reconciled when it is loaded.
3. There is a new test and a new test data file for this fix.