### PR TITLE
Fixed missing system modules in app wrapper after upgrade to Python 3.6

### DIFF
--- a/hscommon/build.py
+++ b/hscommon/build.py
@@ -415,11 +415,12 @@ def copy_embeddable_python_dylib(dst):
 
 def collect_stdlib_dependencies(script, dest_folder, extra_deps=None):
     sysprefix = sys.prefix # could be a virtualenv
-    real_lib_prefix = sysconfig.get_config_var('LIBDEST')
+    # python 3.6's resources gets installed under a symlink, at least under brew on macOS
+    real_lib_prefix = os.path.realpath(sysconfig.get_config_var('LIBDEST'))
     def is_stdlib_path(path):
         # A module path is only a stdlib path if it's in either sys.prefix or
         # sysconfig.get_config_var('prefix') (the 2 are different if we are in a virtualenv) and if
-        # there's no "site-package in the path.
+        # there's no "site-package" in the path.
         if not path:
             return False
         if 'site-package' in path:


### PR DESCRIPTION
After upgrading to Python 3.6 [using brew on macOS 10.12], moneyGuru kept crashing on startup. The error was:

> File "build/moneyGuru.app/Contents/Resources/py/encodings/__init__.py", line 31, in <module>
> ModuleNotFoundError: No module named 'codecs'

The problem was that none of the system modules had been copied into the app wrapper because the path to them -- as supplied by get_path('stdlib') in sysconfig.py -- included a symlink that made the path not match exactly what hscommon/build.py's collect_stdlib_dependencies expected.

Simple fix: Normalize the path using os.path.realpath before comparing with it.