### PR TITLE
Allowed app to do unencrypted HTTP requests

### DIFF
--- a/cocoa/InfoTemplate.plist
+++ b/cocoa/InfoTemplate.plist
@@ -107,8 +107,8 @@
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
 	<string>hsft</string>
-    <key>CFBundleShortVersionString</key>
-    <string>{version}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>{version}</string>
 	<key>CFBundleVersion</key>
 	<string>{version}</string>
 	<key>NSHumanReadableCopyright</key>
@@ -121,5 +121,9 @@
 	<string>http://www.hardcoded.net/updates/moneyguru.appcast</string>
 	<key>SUPublicDSAKeyFile</key>
 	<string>dsa_pub.pem</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+          <key>NSAllowsArbitraryLoads</key><true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Running moneyGuru under macOS 10.12 Sierra will log the following message at startup:

"App Transport Security has blocked a cleartext HTTP (http://) resource load since it is insecure. Temporary exceptions can be configured via your app's Info.plist file."

I thought it was referring to the http://www.bankofcanada.ca/... URL used to download currency rates, but those seem to come through anyway so either it's not blocking them as claimed [yet] or this is about some other URL.

Anyway, got rid of the pesky little error by enabling non-HTTPS requests in the app's Info.plist.