### PR TITLE
Avoid duplicate logging to both stderr and NSLog

### DIFF
--- a/cocoa/mg_cocoa.py
+++ b/cocoa/mg_cocoa.py
@@ -8,7 +8,7 @@ import logging
 import os.path as op
 from objp.util import pyref, dontwrap, nsrect, nssize, nspoint
 
-from cocoa import install_exception_hook, proxy, install_cocoa_logger
+from cocoa import install_exception_hook, proxy, CocoaHandler
 from cocoa.inter import (PyGUIObject, GUIObjectView, PyTextField, PyTable, PyColumns, PyOutline,
     OutlineView, PySelectableList, PyBaseApp)
 from hscommon.util import nonone
@@ -41,9 +41,9 @@ import urllib.request
 class PyMoneyGuruApp(PyBaseApp):
     def __init__(self):
         LOGGING_LEVEL = logging.DEBUG if proxy.prefValue_('DebugMode') else logging.WARNING
-        logging.basicConfig(level=LOGGING_LEVEL, format='%(levelname)s %(message)s')
+        logging.basicConfig(level=LOGGING_LEVEL, format='%(levelname)s %(message)s',
+                            handlers=[CocoaHandler()])
         install_exception_hook('https://github.com/hsoft/moneyguru/issues')
-        install_cocoa_logger()
         logging.debug('started in debug mode')
         cache_path = op.join(proxy.getCachePath(), 'moneyGuru')
         appdata_path = op.join(proxy.getAppdataPath(), 'moneyGuru')

--- a/cocoalib/cocoa/__init__.py
+++ b/cocoalib/cocoa/__init__.py
@@ -106,9 +106,6 @@ class CocoaHandler(logging.Handler):
         LOG_BUFFER.append(msg)
         del LOG_BUFFER[:-20]
 
-def install_cocoa_logger():
-    logging.getLogger().addHandler(CocoaHandler())
-
 def patch_threaded_job_performer():
     # _async_run, under cocoa, has to be run within an autorelease pool to prevent leaks.
     # You only need this patch is you use one of CocoaProxy's function (which allocate objc


### PR DESCRIPTION
When turning on debug logging on a Mac, log output would both go to NSLog as well as stderr, thus duplicating all log entries if you were to ran the app from the command line. Fixed by supplying our NSLog based log handler directly to the python logger.