### PR TITLE
Fixed year handling in macOS date formats

### DIFF
--- a/core/model/date.py
+++ b/core/model/date.py
@@ -559,6 +559,9 @@ class DateFormat:
         if m_separators:
             self.separator = m_separators.group()
             elements = format.split(self.separator)
+            # macOS (and possibly others) use 'y' to denote the year with a non-zero filled century.
+            # Since there is no % equivalent, we'll just use 'yyyy' here instead.
+            elements = ['yyyy' if x == 'y' else x for x in elements]
             if all(elem in self.ISO2SYS for elem in elements):
                 self.elements = elements
 
@@ -606,3 +609,5 @@ class DateFormat:
         repl_elems = [self.ISO2SYS[elem] for elem in self.elements]
         return self.separator.join(repl_elems)
 
+# Default user format
+DateFormat.user = DateFormat(None)

--- a/core/model/date.py
+++ b/core/model/date.py
@@ -608,6 +608,3 @@ class DateFormat:
         """Returns the format as sys (``%d-%m-%Y``)."""
         repl_elems = [self.ISO2SYS[elem] for elem in self.elements]
         return self.separator.join(repl_elems)
-
-# Default user format
-DateFormat.user = DateFormat(None)

--- a/core/tests/model/date_test.py
+++ b/core/tests/model/date_test.py
@@ -23,6 +23,8 @@ def test_clean_format():
     eq_(clean_format('EEEE/MMMM/dd/yyyy'), 'dd/MM/yyyy')
     # We force a numerical date format (this means no MMM)
     eq_(clean_format('MMM.yyyy.dd'), 'MM.yyyy.dd')
+    # We substitute 'yyyy' for 'y'
+    eq_(clean_format('y-MM-dd'), 'yyyy-MM-dd')
 
 def test_parse_date():
     eq_(parse_date('11/10/2007', 'dd/MM/yyyy'), date(2007, 10, 11))


### PR DESCRIPTION
I have set the system date format to yyyy-MM-dd on my Mac, but when I started using moneyGuru, I found that it would produce dates of the form dd-MM-yyyy instead. The reason for this is that macOS (and possibly others) use a single 'y' to denote a non-zerofilled complete year. moneyGuru didn't recognize this and defaulted to its fallback format instead.

Fixed by substituting 'yyyy' for 'y' before parsing the format string. This will give us zero filled centuries for years < 1000, but that's about as close as we can get giving strftime's limitations. Hopefully, there's no real need to process historic accounting records for Roman times anyway.