### PR TITLE
Fixed currency fetching for ranges > 30 days

### DIFF
--- a/core/model/currency.py
+++ b/core/model/currency.py
@@ -31,7 +31,7 @@ class Currency:
 
     A ``Currency`` instance is created with either a 3-letter ISO code or with a full name. If it's
     present in the database, an instance will be returned. If not, ``ValueError`` is raised. The
-    easiest way to access a currency instance, however, if by using module-level constants. For
+    easiest way to access a currency instance, however, is by using module-level constants. For
     example::
 
         >>> from hscommon.currency import USD, EUR
@@ -50,6 +50,7 @@ class Currency:
     def __new__(cls, code=None, name=None):
         """Returns the currency with the given code."""
         assert (code is None and name is not None) or (code is not None and name is None)
+        code = code.upper()
         if code is not None:
             try:
                 return cls.by_code[code]
@@ -81,6 +82,7 @@ class Currency:
 
         ``priority`` determines the order of currencies in :meth:`all`. Lower priority goes first.
         """
+        code = code.upper()
         if code in Currency.by_code:
             return Currency.by_code[code]
         assert name not in Currency.by_name
@@ -384,10 +386,11 @@ class RatesDB:
                     range_end = cached_start - timedelta(days=1)
             # We don't want to fetch ranges that are too big. It can cause various problems, such
             # as hangs. We prefer to take smaller bites.
-            if (range_end - range_start).days > 30:
-                range_start = range_end - timedelta(days=30)
-            if range_start <= range_end:
-                currencies_and_range.append((currency, range_start, range_end))
+            cur_start = cur_end = start_date
+            while cur_end < range_end:
+                cur_end = min(cur_end + timedelta(days=30), range_end)
+                currencies_and_range.append((currency, cur_start, cur_end))
+                cur_start = cur_end
             self._fetched_ranges[currency] = (start_date, date.today())
         if self.async:
             threading.Thread(target=do).start()

--- a/core/model/currency.py
+++ b/core/model/currency.py
@@ -386,7 +386,7 @@ class RatesDB:
                     range_end = cached_start - timedelta(days=1)
             # We don't want to fetch ranges that are too big. It can cause various problems, such
             # as hangs. We prefer to take smaller bites.
-            cur_start = cur_end = start_date
+            cur_start = cur_end = range_start
             while cur_end < range_end:
                 cur_end = min(cur_end + timedelta(days=30), range_end)
                 currencies_and_range.append((currency, cur_start, cur_end))

--- a/core/model/currency.py
+++ b/core/model/currency.py
@@ -50,8 +50,8 @@ class Currency:
     def __new__(cls, code=None, name=None):
         """Returns the currency with the given code."""
         assert (code is None and name is not None) or (code is not None and name is None)
-        code = code.upper()
         if code is not None:
+            code = code.upper()
             try:
                 return cls.by_code[code]
             except KeyError:

--- a/core/tests/model/currency_test.py
+++ b/core/tests/model/currency_test.py
@@ -51,8 +51,9 @@ def test_async_and_repeat():
     # If you make an ensure_rates() call and then the same call right after (before the first one
     # is finished, the server will not be hit twice.
     db, log = set_ratedb_for_tests(async=True, slow_down_provider=True)
-    db.ensure_rates(date(2008, 5, 20), ['USD'])
-    db.ensure_rates(date(2008, 5, 20), ['USD'])
+    lastweek = date.today() - timedelta(days=7)
+    db.ensure_rates(lastweek, ['USD'])
+    db.ensure_rates(lastweek, ['USD'])
     jointhreads()
     eq_(len(log), 1)
 
@@ -69,10 +70,12 @@ def test_seek_rate():
 def test_ask_for_rates_in_the_past():
     # If a rate is asked for a date lower than the lowest fetched date, fetch that range.
     db, log = set_ratedb_for_tests()
-    db.ensure_rates(date(2008, 5, 20), ['USD']) # fetch some rates
-    db.ensure_rates(date(2008, 5, 19), ['USD']) # this one should also fetch rates
+    someday = date.today() - timedelta(days=4)
+    db.ensure_rates(someday, ['USD']) # fetch some rates
+    otherday = someday - timedelta(days=6)
+    db.ensure_rates(otherday, ['USD']) # this one should also fetch rates
     eq_(len(log), 2)
-    eq_(log[1], (date(2008, 5, 19), date(2008, 5, 19), 'USD'))
+    eq_(log[1], (otherday, someday - timedelta(days=1), 'USD'))
 
 def test_ask_for_rates_in_the_future(monkeypatch):
     # If a rate is asked for a date equal or higher than the lowest fetched date, fetch cached_end - today.


### PR DESCRIPTION
Old currency rates would not be retrieved outside of a 30 day window. You can reproduce this by clearing out currencies.db and opening a moneyGuru file with old transactions in it. Note that the currency rate will stay the same for anything older than 30 days ago. Fixed by queueing up requests for the whole time period in 30 day chunks.
