### PR TITLE
Not everyone wants to enter dates with the day first

### DIFF
--- a/cocoa/controllers/MGAppDelegate.h
+++ b/cocoa/controllers/MGAppDelegate.h
@@ -17,6 +17,7 @@ http://www.gnu.org/licenses/gpl-3.0.html
     NSWindow *preferencesPanel;
     NSTextField *autoSaveIntervalField;
     NSButton *autoDecimalPlaceButton;
+    NSButton *dateEntryOrderButton;
     SUUpdater *updater;
     NSMenuItem *customDateRangeItem1;
     NSMenuItem *customDateRangeItem2;
@@ -30,6 +31,7 @@ http://www.gnu.org/licenses/gpl-3.0.html
 @property (readwrite, retain) NSWindow *preferencesPanel;
 @property (readwrite, retain) NSTextField *autoSaveIntervalField;
 @property (readwrite, retain) NSButton *autoDecimalPlaceButton;
+@property (readwrite, retain) NSButton *dateEntryOrderButton;
 @property (readwrite, retain) SUUpdater *updater;
 @property (readwrite, retain) NSMenuItem *customDateRangeItem1;
 @property (readwrite, retain) NSMenuItem *customDateRangeItem2;

--- a/cocoa/controllers/MGAppDelegate.m
+++ b/cocoa/controllers/MGAppDelegate.m
@@ -20,6 +20,7 @@ http://www.gnu.org/licenses/gpl-3.0.html
 @synthesize preferencesPanel;
 @synthesize autoSaveIntervalField;
 @synthesize autoDecimalPlaceButton;
+@synthesize dateEntryOrderButton;
 @synthesize updater;
 @synthesize customDateRangeItem1;
 @synthesize customDateRangeItem2;
@@ -178,6 +179,7 @@ http://www.gnu.org/licenses/gpl-3.0.html
     // binding cannot be done in the NIB, it has to be done manually here.
     [autoSaveIntervalField bind:@"value" toObject:self withKeyPath:@"model.autoSaveInterval" options:nil];
     [autoDecimalPlaceButton bind:@"value" toObject:self withKeyPath:@"model.autoDecimalPlace" options:nil];
+    [dateEntryOrderButton bind:@"value" toObject:self withKeyPath:@"model.dayFirstDateEntry" options:nil];
 }
 
 - (void)applicationWillTerminate:(NSNotification *)aNotification

--- a/cocoa/mg_cocoa.py
+++ b/cocoa/mg_cocoa.py
@@ -89,6 +89,12 @@ class PyMoneyGuruApp(PyBaseApp):
     def setAutoDecimalPlace_(self, value: bool):
         self.model.auto_decimal_place = value
 
+    def dayFirstDateEntry(self) -> bool:
+        return self.model.day_first_date_entry
+
+    def setDayFirstDateEntry_(self, value: bool):
+        self.model.day_first_date_entry = value
+
     def showScheduleScopeDialog(self) -> bool:
         return self.model.show_schedule_scope_dialog
 

--- a/cocoa/ui/preferences_panel.py
+++ b/cocoa/ui/preferences_panel.py
@@ -1,7 +1,7 @@
 ownerclass = 'MGAppDelegate'
 ownerimport = 'MGAppDelegate.h'
 
-result = Window(442, 193, "moneyGuru Preferences")
+result = Window(442, 213, "moneyGuru Preferences")
 autosaveIntervalLabel = Label(result, "Auto-save interval:")
 autosaveIntervalField = TextField(result)
 autosaveIntervalLabel2 = Label(result, "minute(s) (0 for none)")
@@ -12,11 +12,13 @@ printFontSizeLabel = Label(result, "Printing font size:")
 printFontSizeCombo = Combobox(result, items=fontsizes)
 scopeDialogBox = Checkbox(result, "Show scope dialog when modifying a scheduled transaction")
 decimalPlacesBox = Checkbox(result, "Automatically place decimals when typing")
+dateEntryOrderBox = Checkbox(result, "Enter dates in day → month → year order")
 updatesBox = Checkbox(result, "Automatically check for updates")
 debugBox = Checkbox(result, "Debug mode (restart required)")
 
 owner.autoSaveIntervalField = autosaveIntervalField
 owner.autoDecimalPlaceButton = decimalPlacesBox
+owner.dateEntryOrderButton = dateEntryOrderBox
 
 result.canMinimize = result.canResize = False
 defaultFont = Font('Lucida Grande', 12)
@@ -24,7 +26,7 @@ for label in [autosaveIntervalLabel, fontSizeLabel, printFontSizeLabel]:
     label.alignment = TextAlignment.Right
     label.width = 175
     label.font = defaultFont
-for view in [autosaveIntervalLabel2, scopeDialogBox, decimalPlacesBox, updatesBox, debugBox]:
+for view in [autosaveIntervalLabel2, scopeDialogBox, decimalPlacesBox, dateEntryOrderBox, updatesBox, debugBox]:
     view.font = defaultFont
 autosaveIntervalField.formatter = NumberFormatter(NumberStyle.Decimal)
 autosaveIntervalField.formatter.maximumFractionDigits = 0
@@ -44,6 +46,6 @@ layout = VHLayout([
     ], vmargin=4, hfillers={autosaveIntervalLabel2, })
 layout.moveTo(Pack.UpperLeft)
 layout.fill(Pack.Right)
-layout2 = VLayout([scopeDialogBox, decimalPlacesBox, updatesBox, debugBox], margin=6)
+layout2 = VLayout([scopeDialogBox, decimalPlacesBox, dateEntryOrderBox, updatesBox, debugBox], margin=6)
 layout2.moveNextTo(layout, Pack.Below, margin=8)
 layout2.fill(Pack.Right)

--- a/core/app.py
+++ b/core/app.py
@@ -203,7 +203,7 @@ class Application(Broadcaster):
             self._autosave_timer = None
 
     def _update_date_entry_order(self):
-        DateWidget.setEntryFormat(self._day_first_date_entry and "d m y")
+        DateWidget.setDMYEntryOrder(self._day_first_date_entry)
 
     def _load_custom_ranges(self):
         custom_ranges = self.get_default(PreferenceNames.CustomRanges)

--- a/core/app.py
+++ b/core/app.py
@@ -17,6 +17,8 @@ import importlib
 from hscommon.notify import Broadcaster
 from hscommon.util import nonone
 
+from .gui.date_widget import DateWidget
+
 from .const import DATE_FORMAT_FOR_PREFERENCES
 from .model import currency
 from .model.amount import parse_amount, format_amount
@@ -36,6 +38,7 @@ class PreferenceNames:
     HadFirstLaunch = 'HadFirstLaunch'
     AutoSaveInterval = 'AutoSaveInterval'
     AutoDecimalPlace = 'AutoDecimalPlace'
+    DayFirstDateEntry = 'DayFirstDateEntry'
     CustomRanges = 'CustomRanges'
     ShowScheduleScopeDialog = 'ShowScheduleScopeDialog'
     DisabledCorePlugins = 'DisabledCorePlugins'
@@ -167,6 +170,7 @@ class Application(Broadcaster):
         self._autosave_timer = None
         self._autosave_interval = self.get_default(PreferenceNames.AutoSaveInterval, 10)
         self._auto_decimal_place = self.get_default(PreferenceNames.AutoDecimalPlace, False)
+        self._day_first_date_entry = self.get_default(PreferenceNames.DayFirstDateEntry, False)
         self._show_schedule_scope_dialog = self.get_default(PreferenceNames.ShowScheduleScopeDialog, True)
         self.saved_custom_ranges = [None] * 3
         self._load_custom_ranges()
@@ -180,6 +184,7 @@ class Application(Broadcaster):
         self._load_user_plugins()
         self._hook_currency_plugins()
         self._update_autosave_timer()
+        self._update_date_entry_order()
 
     # --- Private
     def _autosave_all_documents(self):
@@ -196,6 +201,9 @@ class Application(Broadcaster):
             self._autosave_timer.start()
         else:
             self._autosave_timer = None
+
+    def _update_date_entry_order(self):
+        DateWidget.setEntryFormat(self._day_first_date_entry and "d m y")
 
     def _load_custom_ranges(self):
         custom_ranges = self.get_default(PreferenceNames.CustomRanges)
@@ -433,6 +441,21 @@ class Application(Broadcaster):
             return
         self._auto_decimal_place = value
         self.set_default(PreferenceNames.AutoDecimalPlace, value)
+
+    @property
+    def day_first_date_entry(self):
+        """*get/set bool*. Whether the user wants to enter dates in day -> month -> year order or
+        the natural left-to-right order in the user's date format.
+        """
+        return self._day_first_date_entry
+
+    @day_first_date_entry.setter
+    def day_first_date_entry(self, value):
+        if value == self._day_first_date_entry:
+            return
+        self._day_first_date_entry = value
+        self.set_default(PreferenceNames.DayFirstDateEntry, value)
+        self._update_date_entry_order()
 
     @property
     def show_schedule_scope_dialog(self):

--- a/core/gui/date_widget.py
+++ b/core/gui/date_widget.py
@@ -129,8 +129,8 @@ class DateWidget:
 
     def type(self, stuff):
         if stuff == self._format.separator:
-            if self._flush_buffer():
-                self._next()
+            self._flush_buffer()
+            self._next()
             return
         if stuff in {'t', 'T'}:
             self._buffer = ''

--- a/core/gui/date_widget.py
+++ b/core/gui/date_widget.py
@@ -25,7 +25,7 @@ FMT_ELEM = {
 }
 
 class DateWidget:
-    # Should dates be entered in day -> month -> year order instead of the normal left-to-right order?
+    # Should dates be entered in day -> month -> year order instead of just left-to-right order?
     _dmyOrder = False
 
     @classmethod
@@ -57,7 +57,9 @@ class DateWidget:
 
     def _next(self):
         if not self.__class__._dmyOrder:
-            self.right()
+            # right() will wrap but we shouldn't do that
+            if self._selected != self._order[2]:
+                self.right()
         elif self._selected == DAY:
             self._selected = MONTH
         elif self._selected == MONTH:

--- a/core/gui/date_widget.py
+++ b/core/gui/date_widget.py
@@ -31,7 +31,10 @@ class DateWidget:
         fmt_elems = format.elements
         self._order = [FMT_ELEM[elem] for elem in fmt_elems]
         self._elem2fmt = dict(zip(self._order, fmt_elems))
-        self._selected = DAY
+        self._sel_order = []
+        for elem in self._format.elements:
+            self._sel_order.append(FMT_ELEM.get(elem))
+        self._selected = self._sel_order[0]
         self._buffer = ''
         self._day = 0
         self._month = 0
@@ -40,10 +43,13 @@ class DateWidget:
 
     # --- Private
     def _next(self):
-        if self._selected == DAY:
-            self._selected = MONTH
-        elif self._selected == MONTH:
-            self._selected = YEAR
+        setsel = False
+        for sel in self._sel_order:
+            if self._selected == sel:
+                setsel = True
+            elif setsel:
+                self._selected = sel
+                break
 
     def _flush_buffer(self, force=False):
         # Returns a bool indicating if the buffer was effectively flushed
@@ -92,7 +98,7 @@ class DateWidget:
     def exit(self):
         self._flush_buffer(force=True)
         self.date # will correct the date
-        self._selected = DAY
+        self._selected = self._sel_order[0]
 
     def increase(self):
         self._increase_or_decrease(increase=True)

--- a/core/gui/date_widget.py
+++ b/core/gui/date_widget.py
@@ -6,8 +6,6 @@
 # which should be included with this package. The terms are also available at
 # http://www.gnu.org/licenses/gpl-3.0.html
 
-import sys
-
 from datetime import date
 
 from ..model.date import format_year_month_day, inc_day, inc_month, inc_year, DateFormat

--- a/core/gui/date_widget.py
+++ b/core/gui/date_widget.py
@@ -49,14 +49,14 @@ class DateWidget:
     # --- Private
     @property
     def _selected(self):
-        return self.__selected or (DAY if self.__class__._dmyOrder else self._order[0])
+        return self.__selected or (DAY if self._dmyOrder else self._order[0])
 
     @_selected.setter
     def _selected(self, value):
         self.__selected = value
 
     def _next(self):
-        if not self.__class__._dmyOrder:
+        if not self._dmyOrder:
             # right() will wrap but we shouldn't do that
             if self._selected != self._order[2]:
                 self.right()

--- a/core/tests/gui/date_widget_test.py
+++ b/core/tests/gui/date_widget_test.py
@@ -417,25 +417,22 @@ class TestCaseYYYYMMDDWithDot:
         """The day is selected, which is in last position"""
         eq_(self.w.selection, (8, 9))
 
+    def test_type(self):
+        """Enter an partial (abbreviated) date.
+        The period will move the selection from the day field to the month field"""
+        for ch in '2.3':
+            self.w.type(ch)
+        eq_(self.w.text, '2008.3 .02')
+
     def test_text(self):
         """Text is the formatted date"""
         eq_(self.w.text, '2008.06.12')
 
 
-class TestCaseYYYYMMDDWithDash:
+class TestCaseYYYYMMDDWithHyphen:
     def setup_method(self, method):
         self.w = DateWidget('yyyy-MM-dd')
         self.w.date = date(2008, 6, 12)
-
-    def test_left(self):
-        """Selects the day which is last"""
-        self.w.left()
-        eq_(self.w.selection, (8, 9))
-
-    def test_right(self):
-        """Selects the month which is in the middle"""
-        self.w.right()
-        eq_(self.w.selection, (5, 6))
 
     def test_selection(self):
         """The year is selected, which is in first position"""
@@ -444,6 +441,12 @@ class TestCaseYYYYMMDDWithDash:
     def test_text(self):
         """Text is the formatted date"""
         eq_(self.w.text, '2008-06-12')
+
+    def test_type(self):
+        """Enter an (abbreviated) date with each hyphen moving forward to the next subfield"""
+        for ch in '7-5-11':
+            self.w.type(ch)
+        eq_(self.w.text, '2007-05-11')
 
 
 class TestCaseDDMMYYYYOnJanuaryFocusOnMonth:

--- a/core/tests/gui/date_widget_test.py
+++ b/core/tests/gui/date_widget_test.py
@@ -133,11 +133,6 @@ class TestCaseDDMMYYYYWithSlash:
         self.w.type('!')
         self._assert_unchanged()
 
-    def test_type_slash(self):
-        """Typing the separator doesn't do anything because we're not buffering"""
-        self.w.type('/')
-        self._assert_unchanged()
-
     def test_type_t(self, monkeypatch):
         # Typing 't' sets the date to today
         monkeypatch.patch_today(2010, 9, 8)
@@ -293,7 +288,7 @@ class TestCaseDDMMYYYYWithSlashBuffering:
         eq_(self.w.selection, (3, 4))
 
     def test_type_slash(self):
-        """Typing the separator saves the bufferand goes to the month field"""
+        """Typing the separator saves the buffer and goes to the month field"""
         self.w.type('/')
         eq_(self.w.text, '01/06/2008')
         eq_(self.w.date, date(2008, 6, 1))
@@ -603,7 +598,8 @@ class TestCaseInvalidBuffer:
         eq_(self.w.text, '12/06/2008')
 
     def test_type_sep(self):
-        # There was a crash when a sep-caused _flush_buffer would be called with an invalid value
+        # Move to the next subfield and insert a '1'
         self.w.type('/')
-        eq_(self.w.text, '0 /06/2008') # don't do anything (stay on DAY)
+        self.w.type('1')
+        eq_(self.w.text, '12/1 /2008')
 

--- a/core/tests/gui/date_widget_test.py
+++ b/core/tests/gui/date_widget_test.py
@@ -400,7 +400,8 @@ class TestCaseDDMMYYYYWithHyphen:
 
 class TestCaseYYYYMMDDWithDot:
     def setup_method(self, method):
-        self.w = DateWidget('yyyy.MM.dd', 'd M y')
+        DateWidget.setDMYEntryOrder(True)
+        self.w = DateWidget('yyyy.MM.dd')
         self.w.date = date(2008, 6, 12)
 
     def test_left(self):
@@ -431,6 +432,7 @@ class TestCaseYYYYMMDDWithDot:
 
 class TestCaseYYYYMMDDWithHyphen:
     def setup_method(self, method):
+        DateWidget.setDMYEntryOrder(False)
         self.w = DateWidget('yyyy-MM-dd')
         self.w.date = date(2008, 6, 12)
 

--- a/core/tests/gui/date_widget_test.py
+++ b/core/tests/gui/date_widget_test.py
@@ -404,6 +404,9 @@ class TestCaseYYYYMMDDWithDot:
         self.w = DateWidget('yyyy.MM.dd')
         self.w.date = date(2008, 6, 12)
 
+    def teardown_method(self, method):
+        DateWidget.setDMYEntryOrder(False)
+
     def test_left(self):
         """Selects the month which is in the middle"""
         self.w.left()
@@ -432,7 +435,6 @@ class TestCaseYYYYMMDDWithDot:
 
 class TestCaseYYYYMMDDWithHyphen:
     def setup_method(self, method):
-        DateWidget.setDMYEntryOrder(False)
         self.w = DateWidget('yyyy-MM-dd')
         self.w.date = date(2008, 6, 12)
 

--- a/core/tests/gui/date_widget_test.py
+++ b/core/tests/gui/date_widget_test.py
@@ -400,7 +400,7 @@ class TestCaseDDMMYYYYWithHyphen:
 
 class TestCaseYYYYMMDDWithDot:
     def setup_method(self, method):
-        self.w = DateWidget('yyyy.MM.dd')
+        self.w = DateWidget('yyyy.MM.dd', 'd M y')
         self.w.date = date(2008, 6, 12)
 
     def test_left(self):
@@ -420,6 +420,30 @@ class TestCaseYYYYMMDDWithDot:
     def test_text(self):
         """Text is the formatted date"""
         eq_(self.w.text, '2008.06.12')
+
+
+class TestCaseYYYYMMDDWithDash:
+    def setup_method(self, method):
+        self.w = DateWidget('yyyy-MM-dd')
+        self.w.date = date(2008, 6, 12)
+
+    def test_left(self):
+        """Selects the day which is last"""
+        self.w.left()
+        eq_(self.w.selection, (8, 9))
+
+    def test_right(self):
+        """Selects the month which is in the middle"""
+        self.w.right()
+        eq_(self.w.selection, (5, 6))
+
+    def test_selection(self):
+        """The year is selected, which is in first position"""
+        eq_(self.w.selection, (0, 3))
+
+    def test_text(self):
+        """Text is the formatted date"""
+        eq_(self.w.text, '2008-06-12')
 
 
 class TestCaseDDMMYYYYOnJanuaryFocusOnMonth:

--- a/qt/controller/preferences_panel.py
+++ b/qt/controller/preferences_panel.py
@@ -67,6 +67,8 @@ class PreferencesPanel(QDialog):
         self.verticalLayout.addWidget(self.scopeDialogCheckBox)
         self.autoDecimalPlaceCheckBox = QCheckBox(tr("Automatically place decimals when typing"), self)
         self.verticalLayout.addWidget(self.autoDecimalPlaceCheckBox)
+        self.dateEntryBox = QCheckBox(tr("Enter dates in day → month → year order"), self)
+        self.verticalLayout.addWidget(self.dateEntryBox)
         self.debugModeCheckBox = QCheckBox(tr("Debug mode (restart required)"), self)
         self.verticalLayout.addWidget(self.debugModeCheckBox)
         self.verticalLayout.addItem(verticalSpacer())
@@ -82,6 +84,7 @@ class PreferencesPanel(QDialog):
         self.fontSizeSpinBox.setValue(self.app.prefs.tableFontSize)
         self.scopeDialogCheckBox.setChecked(appm.show_schedule_scope_dialog)
         self.autoDecimalPlaceCheckBox.setChecked(appm.auto_decimal_place)
+        self.dateEntryBox.setChecked(appm.day_first_date_entry)
         self.debugModeCheckBox.setChecked(self.app.prefs.debugMode)
         try:
             langindex = SUPPORTED_LANGUAGES.index(self.app.prefs.language)
@@ -99,6 +102,7 @@ class PreferencesPanel(QDialog):
         self.app.prefs.tableFontSize = self.fontSizeSpinBox.value()
         appm.show_schedule_scope_dialog = self.scopeDialogCheckBox.isChecked()
         appm.auto_decimal_place = self.autoDecimalPlaceCheckBox.isChecked()
+        appm.day_first_date_entry = self.dateEntryBox.isChecked()
         self.app.prefs.debugMode = self.debugModeCheckBox.isChecked()
         lang = SUPPORTED_LANGUAGES[self.languageComboBox.currentIndex()]
         oldlang = self.app.prefs.language


### PR DESCRIPTION
My preferred date format follows the ISO standard (YYYY-MM-DD), but moneyGuru insists on me entering them with the day first, then month, then year, i.e. backwards from how they are written and how I normally would enter them. At first I thought this was a simple bug and fixed it to always be left-to-right in whatever format the user prefers, but then I came across an article on the moneyGuru website that promoted the day->month->year entry as a feature, so I added a preference that allowed the old behavior to be reenabled. I still let the default be left-to-right as this would arguably be the most "natural" and expected behavior.