### PR TITLE
Fuzzy Date plugin

### DIFF
--- a/core/plugin/__init__.py
+++ b/core/plugin/__init__.py
@@ -27,6 +27,7 @@ def get_all_core_plugin_modules():
         account_list, currency_rates, payee_breakdown, boc_currency_provider,
         yahoo_currency_provider, stale_currency_provider,
         base_import_actions, base_import_bind,
+        fuzzy_date_bind,
     )
     return [
         account_list,
@@ -37,5 +38,6 @@ def get_all_core_plugin_modules():
         stale_currency_provider,
         base_import_actions,
         base_import_bind,
+        fuzzy_date_bind,
     ]
 

--- a/core/plugin/fuzzy_date_bind.py
+++ b/core/plugin/fuzzy_date_bind.py
@@ -1,0 +1,72 @@
+# Copyright 2017 Georg Drees
+# Copyright 2016 Virgil Dupras
+#
+# This software is licensed under the "GPLv3" License as described in the "LICENSE" file,
+# which should be included with this package. The terms are also available at
+# http://www.gnu.org/licenses/gpl-3.0.html
+#
+# Adapted from base_import_bind.py
+
+import datetime
+from itertools import product
+import logging
+
+from core.plugin import ImportBindPlugin, EntryMatch
+
+#
+# TODO: possible error source: date range selected for moneyguru.
+#
+#       Does it influence existing_entries below? Are there older entries that don't appear?
+#
+
+
+class FuzzyDateBind(ImportBindPlugin):
+    """Check for each imported txn if there is an existing txn that is within [date - DELTA_T, date + DELTA_T]
+    and has at least one matching split amount.
+    """
+    NAME = "Fuzzy Date Bind Plugin"
+    AUTHOR = "Georg Drees"
+
+    BASE_CONFIDENCE = 0.75  # could be increased when implement memo matching / associations...
+    DELTA_T = datetime.timedelta(4)  # 4 days
+    # positive key: imported is after existing
+    # (e.g. money taken from account (import) after purchase date (manual entry, existing))
+    PENALTIES = {-7: .13,
+                 -6: .12,
+                 -5: .11,
+                 -4: .10,
+                 -3: .09,
+                 -2: .08,
+                 -1: .07,
+                 0: 0,
+                 +1: .01,
+                 +2: .02,
+                 +3: .03,
+                 +4: .04,
+                 +5: .05,
+                 +6: .06,
+                 +7: .07,
+                 }
+
+    def match_entries(self,
+                      target_account,
+                      document,
+                      import_document,
+                      existing_entries,
+                      imported_entries):
+        matches = []
+        will_import = True
+
+        entry_pairs = [(i, e) for i, e in product(imported_entries, existing_entries)
+                       if abs(i.date - e.date) <= self.DELTA_T]
+
+        for imported_entry, existing_entry in entry_pairs:
+            if any(isplit.amount == esplit.amount
+                   for isplit, esplit in product(imported_entry.splits, existing_entry.splits)):
+                confidence = self.BASE_CONFIDENCE - self.PENALTIES[(imported_entry.date - existing_entry.date).days]
+                logging.debug("Fuzzy Date date range match (%1.3f): %s %s", confidence, imported_entry, existing_entry)
+                # Use "existing, imported" order according to EntryMatch definition
+                logging.debug("Fuzzy Date final confidence: %.3f", min(confidence, 1.00))
+                matches.append(EntryMatch(existing_entry, imported_entry, will_import, min(confidence, 1.00)))
+
+        return matches

--- a/core/plugin/fuzzy_date_bind.py
+++ b/core/plugin/fuzzy_date_bind.py
@@ -67,8 +67,8 @@ class FuzzyDateBind(ImportBindPlugin):
                    for isplit, esplit in product(imported_entry.splits, existing_entry.splits)):
                 confidence = self.BASE_CONFIDENCE - self.PENALTIES[(imported_entry.date - existing_entry.date).days]
                 logging.debug("Fuzzy Date date range match (%1.3f): %s %s", confidence, imported_entry, existing_entry)
-                # Use "existing, imported" order according to EntryMatch definition
                 logging.debug("Fuzzy Date final confidence: %.3f", min(confidence, 1.00))
+                # Use "existing, imported" order according to EntryMatch definition
                 matches.append(EntryMatch(existing_entry, imported_entry, will_import, min(confidence, 1.00)))
 
         return matches

--- a/core/plugin/fuzzy_date_bind.py
+++ b/core/plugin/fuzzy_date_bind.py
@@ -28,7 +28,9 @@ class FuzzyDateBind(ImportBindPlugin):
     AUTHOR = "Georg Drees"
 
     BASE_CONFIDENCE = 0.75  # could be increased when implement memo matching / associations...
-    DELTA_T = datetime.timedelta(4)  # 4 days
+    DELTA_T = datetime.timedelta(4)  # 4 days; you must extend PENALTIES if DELTA_T > 7 days or a KeyError could occur!
+    # PENALTIES must have keys for all integers in the inclusive range [ -DELTA_T.days; +DELTA_T.days ]
+    # to avoid a KeyError on lookup.
     # positive key: imported is after existing
     # (e.g. money taken from account (import) after purchase date (manual entry, existing))
     PENALTIES = {-7: .13,

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -9,11 +9,14 @@
 import os
 import time
 import pytest
+import logging
 
 from hscommon.testutil import pytest_funcarg__app # noqa
 
 from ..model.currency import RatesDB, Currency
 from ..model import currency as currency_module
+
+logging.basicConfig(level=logging.DEBUG)
 
 global_monkeypatch = None
 

--- a/core/tests/plugin/test_fuzzy_date_bind.py
+++ b/core/tests/plugin/test_fuzzy_date_bind.py
@@ -115,8 +115,6 @@ def test_match_for_each_existing_in_range():
 
 
 @mark.xfail(reason="Python does not guarantee unix epoch safety, it depends on system C library.")
-@mark.skipif(FuzzyDateBind.DELTA_T.days < 2,
-             reason="Need FuzzyDateBind.DELTA_T >= 2 to test due to static special dates.")
 def test_unix_epoch():
     # Test using specific dates that could be problematic when the unix time
     # with 32 bit representation overflows. c.f. https://en.wikipedia.org/wiki/Unix_time
@@ -126,23 +124,7 @@ def test_unix_epoch():
     # NOTE:
     # Currently python depends on your system's C library for date functionality
     # during unix epoch change to work correctly.
-    plugin = FuzzyDateBind()
-    existing_entries = list(starmap(create_entry, [
-        (date(2038, 1, 18), 'e1', 11),
-        (date(2038, 1, 20), 'e2', 22),
-        (date(2106, 2, 6), 'e3', 33),
-        (date(2106, 2, 8), 'e4', 44),
-    ]))
-    imported_entries = list(starmap(create_entry, [
-        (date(2038, 1, 20), 'i1', 11),
-        (date(2038, 1, 18), 'i2', 22),
-        (date(2106, 2, 8), 'i3', 33),
-        (date(2106, 2, 6), 'i4', 44),
-    ]))
-    matches = plugin.match_entries(None, None, None, existing_entries, imported_entries)
-    EXPECTED = [('e1', 'i1', True, BASE_CONFIDENCE - PENALTIES[2]),
-                ('e2', 'i2', True, BASE_CONFIDENCE - PENALTIES[-2]),
-                ('e3', 'i3', True, BASE_CONFIDENCE - PENALTIES[2]),
-                ('e4', 'i4', True, BASE_CONFIDENCE - PENALTIES[-2])]
-    result = [(m.existing.description, m.imported.description, m.will_import, m.weight) for m in matches]
-    eq_(result, EXPECTED)
+    eq_((date(2038, 1, 20) - date(2038, 1, 18)).days, 2)
+    eq_((date(2038, 1, 18) - date(2038, 1, 20)).days, -2)
+    eq_((date(2106, 2, 8) - date(2106, 2, 6)).days, 2)
+    eq_((date(2106, 2, 6) - date(2106, 2, 8)).days, -2)

--- a/core/tests/plugin/test_fuzzy_date_bind.py
+++ b/core/tests/plugin/test_fuzzy_date_bind.py
@@ -92,26 +92,26 @@ def test_outside_date_intervall():
 def test_match_for_each_existing_in_range():
     # Verify a match is created for each existing in the date range
     plugin = FuzzyDateBind()
-    num = randint(1, 50)  # to limit the runtime of the test
     DATE = date(2017, 10, 10)
-    existing_entries = list(starmap(create_entry, [
-        (DATE - FuzzyDateBind.DELTA_T - timedelta(1), 'e1out', 42),
-        (DATE + FuzzyDateBind.DELTA_T + timedelta(1), 'e2out', 42),
-    ]))
-    for i in range(num):
-        existing_entries.append(create_entry(DATE + timedelta(randint(-FuzzyDateBind.DELTA_T.days,
-                                                                      +FuzzyDateBind.DELTA_T.days)),
-                                             'random entry',
-                                             42))
-    imported_entries = list(starmap(create_entry, [
-        (DATE, 'i1', 42),
-    ]))
-    matches = plugin.match_entries(None, None, None, existing_entries, imported_entries)
-    result = [(m.existing.description, m.imported.description, m.will_import, m.weight) for m in matches]
-    eq_(len(result), num)
-    for r in result:
-        eq_(r[0], 'random entry')
-        eq_(r[1], 'i1')
+    for num in [0, 1, 2, randint(3, 50)]:  # TODO: Use fuzzer. Arbitrarily limited to limit the test runtime
+        existing_entries = list(starmap(create_entry, [
+            (DATE - FuzzyDateBind.DELTA_T - timedelta(1), 'e1out', 42),
+            (DATE + FuzzyDateBind.DELTA_T + timedelta(1), 'e2out', 42),
+        ]))
+        for i in range(num):
+            existing_entries.append(create_entry(DATE + timedelta(randint(-FuzzyDateBind.DELTA_T.days,
+                                                                          +FuzzyDateBind.DELTA_T.days)),
+                                                 'random entry',
+                                                 42))
+        imported_entries = list(starmap(create_entry, [
+            (DATE, 'i1', 42),
+        ]))
+        matches = plugin.match_entries(None, None, None, existing_entries, imported_entries)
+        result = [(m.existing.description, m.imported.description, m.will_import, m.weight) for m in matches]
+        eq_(len(result), num)
+        for r in result:
+            eq_(r[0], 'random entry')
+            eq_(r[1], 'i1')
 
 
 @mark.xfail(reason="Python does not guarantee unix epoch safety, it depends on system C library.")

--- a/core/tests/plugin/test_fuzzy_date_bind.py
+++ b/core/tests/plugin/test_fuzzy_date_bind.py
@@ -13,7 +13,6 @@
 from datetime import date, timedelta
 from itertools import starmap
 from random import randint
-import logging
 
 from pytest import mark, raises
 
@@ -27,8 +26,6 @@ from ...plugin.fuzzy_date_bind import FuzzyDateBind
 
 BASE_CONFIDENCE = FuzzyDateBind.BASE_CONFIDENCE
 PENALTIES = FuzzyDateBind.PENALTIES
-
-logging.basicConfig(level=logging.DEBUG)
 
 
 def create_entry(entry_date, description, amount):

--- a/core/tests/plugin/test_fuzzy_date_bind.py
+++ b/core/tests/plugin/test_fuzzy_date_bind.py
@@ -1,0 +1,231 @@
+# Copyright 2017 Virgil Dupras, Georg Drees
+#
+# This software is licensed under the "GPLv3" License as described in the "LICENSE" file,
+# which should be included with this package. The terms are also available at
+# http://www.gnu.org/licenses/gpl-3.0.html
+
+#
+# TODO:
+#       - higher level testing:
+#           - verify weight recommendations lead to actually usable result
+#
+
+from datetime import date, timedelta
+from itertools import starmap
+from random import randint
+import logging
+
+from pytest import mark, raises
+
+from hscommon.testutil import eq_
+
+from ...model.amount import Amount
+from ...model.currency import USD
+from ...model.entry import Entry
+from ...model.transaction import Transaction
+from ...plugin.fuzzy_date_bind import FuzzyDateBind
+
+BASE_CONFIDENCE = FuzzyDateBind.BASE_CONFIDENCE
+PENALTIES = FuzzyDateBind.PENALTIES
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def create_entry(entry_date, description, amount):
+    if isinstance(amount, Amount):
+        txn = Transaction(entry_date, description=description, amount=amount)
+    elif isinstance(amount, int) or isinstance(amount, float):
+        txn = Transaction(entry_date, description=description, amount=Amount(amount, USD))
+    else:
+        raise TypeError("amount must be of type model.amount.Amount, int or float!")
+    if not isinstance(description, str):
+        raise TypeError("description must be of type str!")
+    split = txn.splits[0]
+    return Entry(split, split.amount, 0, 0, 0)
+
+
+def test_internal_create_entry_argument_fencing():
+    # Verify that description and amount must be certain types
+    # when created in tests.
+    DATE = date(2017, 10, 10)
+    create_entry(DATE, "string", Amount(42, USD))
+    create_entry(DATE, "string", 42)
+    create_entry(DATE, "string", 4.20)
+    with raises(TypeError):
+        create_entry(DATE, "string", "33")
+        create_entry(DATE, bytes("bad"), 42)
+
+
+@mark.parametrize("do_refine_matches", [(False), (True)])
+def test_single_imported_typical(do_refine_matches):
+    # Verify that FuzzyDateBind.match_entries() returns weights modified
+    # according to FuzzyDateBind.PENALTIES lookup and only if amounts match
+    plugin = FuzzyDateBind()
+    DATE = date(2017, 10, 10)
+    existing_entries = list(starmap(create_entry, [
+        (DATE, 'e1', 42),
+        (DATE + timedelta(2), 'e2', 42),
+        (DATE, 'e3 other amount', 11),
+    ]))
+    imported_entries = list(starmap(create_entry, [
+        (DATE + timedelta(1), 'i1', 42),
+    ]))
+    matches = plugin.match_entries(None, None, None, existing_entries, imported_entries,
+                                   do_refine_matches=do_refine_matches)
+    EXPECTED = [('e1', 'i1', True, BASE_CONFIDENCE - PENALTIES[1]),
+                ('e2', 'i1', True, BASE_CONFIDENCE - PENALTIES[-1])]
+    result = [(m.existing.description, m.imported.description, m.will_import, m.weight) for m in matches]
+    eq_(result, EXPECTED)
+
+
+@mark.parametrize("do_refine_matches", [(False), (True)])
+def test_outside_date_intervall(do_refine_matches):
+    # Verify no matches are returned if all existing are not in date range
+    plugin = FuzzyDateBind()
+    DATE = date(2017, 10, 10)
+    existing_entries = list(starmap(create_entry, [
+        (DATE - FuzzyDateBind.DELTA_T - timedelta(1), 'e1out', 42),
+        (DATE + FuzzyDateBind.DELTA_T + timedelta(1), 'e2out', 42),
+    ]))
+    imported_entries = list(starmap(create_entry, [
+        (DATE, 'i1', 42),
+    ]))
+    matches = plugin.match_entries(None, None, None, existing_entries, imported_entries,
+                                   do_refine_matches=do_refine_matches)
+    result = [(m.existing.description, m.imported.description, m.will_import, m.weight) for m in matches]
+    eq_(len(result), 0)
+
+
+@mark.parametrize("do_refine_matches", [(False), (True)])
+def test_match_for_each_existing_in_range(do_refine_matches):
+    # Verify a match is created for each existing in the date range
+    plugin = FuzzyDateBind()
+    num = randint(1, 50)  # to limit the runtime of the test
+    DATE = date(2017, 10, 10)
+    existing_entries = list(starmap(create_entry, [
+        (DATE - FuzzyDateBind.DELTA_T - timedelta(1), 'e1out', 42),
+        (DATE + FuzzyDateBind.DELTA_T + timedelta(1), 'e2out', 42),
+    ]))
+    for i in range(num):
+        existing_entries.append(create_entry(DATE + timedelta(randint(-FuzzyDateBind.DELTA_T.days,
+                                                                      +FuzzyDateBind.DELTA_T.days)),
+                                             'random entry',
+                                             42))
+    imported_entries = list(starmap(create_entry, [
+        (DATE, 'i1', 42),
+    ]))
+    matches = plugin.match_entries(None, None, None, existing_entries, imported_entries,
+                                   do_refine_matches=do_refine_matches)
+    result = [(m.existing.description, m.imported.description, m.will_import, m.weight) for m in matches]
+    eq_(len(result), num)
+    for r in result:
+        eq_(r[0], 'random entry')
+        eq_(r[1], 'i1')
+
+
+def test_second_imported_matches_numeric_date():
+    # If two txns on the correct day with same amount are imported, the one with
+    # better matching description should get a higher weight, even if second in list
+    plugin = FuzzyDateBind()
+    DATE = date(2017, 10, 10)
+    e1 = 'e1 2017-10-10'
+    existing_entries = list(starmap(create_entry, [
+        (DATE, e1, 42),
+    ]))
+    i1 = 'i1'
+    i2 = 'i2 2017-10-10'
+    imported_entries = list(starmap(create_entry, [
+        (DATE, i1, 42),
+        (DATE, i2, 42),
+    ]))
+    matches = plugin.match_entries(None, None, None, existing_entries, imported_entries,
+                                   do_refine_matches=True)
+    EXPECTED = [(e1, i1, True, BASE_CONFIDENCE),
+                (e1, i2, True, min(BASE_CONFIDENCE + FuzzyDateBind.CONF_PER_MEMODATE_MATCH, 1.00))]
+    result = [(m.existing.description, m.imported.description, m.will_import, m.weight) for m in matches]
+    eq_(result, EXPECTED)
+    assert(EXPECTED[0][-1] < EXPECTED[1][-1])
+
+
+def test_multi_refined_numeric_date():
+    # Verify that refined matching can find more than one match
+    plugin = FuzzyDateBind()
+    DATE = date(2017, 10, 10)
+    e1 = 'e1 for 2017-01-01 until 2017-09-30'
+    existing_entries = list(starmap(create_entry, [
+        (DATE, e1, 42),
+    ]))
+    i1 = 'i1 2017-01-01-2017-09-30'
+    i2 = 'i2 2017-01-01, 2017-09-30 and 2017-01-01 again'
+    imported_entries = list(starmap(create_entry, [
+        (DATE, i1, 42),
+        (DATE, i2, 42),
+    ]))
+    matches = plugin.match_entries(None, None, None, existing_entries, imported_entries,
+                                   do_refine_matches=True)
+    EXPECTED = [(e1, i1, True, min(BASE_CONFIDENCE + 2 * FuzzyDateBind.CONF_PER_MEMODATE_MATCH, 1.00)),
+                # ['2017-01-01', '2017-09-30']  # noqa: E116
+                (e1, i2, True, min(BASE_CONFIDENCE + 3 * FuzzyDateBind.CONF_PER_MEMODATE_MATCH, 1.00))]
+                # ['2017-01-01', '2017-09-30', '2017-01-01']  # noqa: E116
+    result = [(m.existing.description, m.imported.description, m.will_import, m.weight) for m in matches]
+    eq_(result, EXPECTED)
+
+
+def test_multi_refined_numeric_and_en_date():
+    # Verify that refined matching with language adds weight
+    plugin = FuzzyDateBind()
+    DATE = date(2017, 10, 10)
+    e1 = 'e1 for 2017-01-01 and February'
+    existing_entries = list(starmap(create_entry, [
+        (DATE, e1, 42),
+    ]))
+    i1 = 'i1 2017-01-01-2017-09-30'
+    i2 = 'i2 2017-01-01, 2017-09-30 + February'
+    imported_entries = list(starmap(create_entry, [
+        (DATE, i1, 42),
+        (DATE, i2, 42),
+    ]))
+    matches = plugin.match_entries(None, None, None, existing_entries, imported_entries,
+                                   do_refine_matches=True, lang="en")
+    EXPECTED = [(e1, i1, True, min(BASE_CONFIDENCE + 1 * FuzzyDateBind.CONF_PER_MEMODATE_MATCH, 1.00)),
+                # ['2017-01-01']  # noqa: E116
+                (e1, i2, True, min(BASE_CONFIDENCE + 3 * FuzzyDateBind.CONF_PER_MEMODATE_MATCH, 1.00))]
+                # ['2017-01-01', 'February', 'Feb']  # noqa: E116
+    result = [(m.existing.description, m.imported.description, m.will_import, m.weight) for m in matches]
+    eq_(result, EXPECTED)
+
+
+@mark.xfail(reason="Python does not guarantee unix epoch safety, it depends on system C library.")
+@mark.skipif(FuzzyDateBind.DELTA_T.days < 2,
+             reason="Need FuzzyDateBind.DELTA_T >= 2 to test due to static special dates.")
+@mark.parametrize("do_refine_matches", [(False), (True)])
+def test_unix_epoch(do_refine_matches):
+    # Test using specific dates that could be problematic when the unix time
+    # with 32 bit representation overflows. c.f. https://en.wikipedia.org/wiki/Unix_time
+    # --> 03:14:08 UTC on Tuesday, 19 January 2038 for signed 32 bit
+    # --> 06:28:15 UTC on Sunday, 7 February 2106 for unsigned 32 bit
+    #
+    # NOTE:
+    # Currently python depends on your system's C library for date functionality
+    # during unix epoch change to work correctly.
+    plugin = FuzzyDateBind()
+    existing_entries = list(starmap(create_entry, [
+        (date(2038, 1, 18), 'e1', 11),
+        (date(2038, 1, 20), 'e2', 22),
+        (date(2106, 2, 6), 'e3', 33),
+        (date(2106, 2, 8), 'e4', 44),
+    ]))
+    imported_entries = list(starmap(create_entry, [
+        (date(2038, 1, 20), 'i1', 11),
+        (date(2038, 1, 18), 'i2', 22),
+        (date(2106, 2, 8), 'i3', 33),
+        (date(2106, 2, 6), 'i4', 44),
+    ]))
+    matches = plugin.match_entries(None, None, None, existing_entries, imported_entries,
+                                   do_refine_matches=do_refine_matches)
+    EXPECTED = [('e1', 'i1', True, BASE_CONFIDENCE - PENALTIES[2]),
+                ('e2', 'i2', True, BASE_CONFIDENCE - PENALTIES[-2]),
+                ('e3', 'i3', True, BASE_CONFIDENCE - PENALTIES[2]),
+                ('e4', 'i4', True, BASE_CONFIDENCE - PENALTIES[-2])]
+    result = [(m.existing.description, m.imported.description, m.will_import, m.weight) for m in matches]
+    eq_(result, EXPECTED)

--- a/help/en/plugins.rst
+++ b/help/en/plugins.rst
@@ -2,11 +2,14 @@ Plugins
 =======
 
 Since moneyGuru v2.5, it's possible to expand moneyGuru's capability through Python plugins. Plugins
-are Python 3 source files that come in two flavors: "core" and "user. Core plugins are bundled
-directly in moneyGuru and are enabled by default. User plugins are located in the plugin folder (the
-location of that folder depends on the system, but you can open that folder through
-"File --> Open Plugin Folder") and are disabled by default. To install a new user plugin, you can
-simply copy the python source file of that plugin in that folder and restart moneyGuru.
+are Python 3 source files that come in two flavors: "core" and "user".
+
+Core plugins are bundled directly in moneyGuru and most of them are enabled by default, with the exceptions listed below.
+
+User plugins are located in the plugin folder (the location of that folder depends on the system,
+but you can open that folder through "File --> Open Plugin Folder") and are disabled by default.
+To install a new user plugin, you can simply copy the python source file of that plugin in that
+folder and restart moneyGuru.
 
 You can enable and disable plugins through the "Plugin management" view, available whenever you
 open a new tab. Simply check/uncheck the box next to the plugin you want to enable/disable and
@@ -49,6 +52,32 @@ Import match bindings are plugins that allow us to re-define the way we do autom
 importing transactions in an existing account. For now, we only have one core plugin of this type
 that match transactions based on IDs supplied by the OFX format. If you add a plugin of that type,
 additional criterias will be used for matching (for example, you could match based on date+amount).
+
+Core plugins that are not enabled by default
+--------------------------------------------
+
+You can enable any core plugin that is not enabled by default in the same way as you would enable
+a user plugin in the "Plugin management" view as described above on this page.
+
+Fuzzy Date Bind Plugin
+^^^^^^^^^^^^^^^^^^^^^^
+With the ``Fuzzy Date Bind Plugin`` you can let moneyGuru match transactions whose dates are not exactly
+the same but within a certain date range (up to 4 days earlier or later) during import. For a match to
+occurr also at least one amount in the splits of the compared transactions must have the same value.
+
+To help match the most logical pairs the following heuristic is used:
+    * a match with exactly the *same dates* has the highest weight
+    * existing transactions with a date *earlier* than the imported transaction are preferred after that,
+      with a higher weight the closer the dates match.
+    * existing transactions with a date *later* than the imported transaction have the lowest weights
+      which are even more decreased for more distant dates.
+
+Therefore matches with the same dates are matched as they would have been without this plugin and
+the common case of an account withdrawal ('imported' transaction; with e.g. the monthly statement)
+being recorded with a date a few days after the purchase ('existing' transaction, entered e.g. with
+a manual entry) should also be matched automatically.
+
+This plugin is not enabled by default to prevent unexpected behavior.
 
 Creating a plugin
 -----------------

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,5 @@ deps =
 [flake8]
 exclude = .tox,env,build,hscommon,qtlib,cocoalib,cocoa,help,./get-pip.py,./qt/mg_rc.py,./core/tests,run_template_*.py,.waf*,./debian
 max-line-length = 120
-ignore = W391,W293,E302,E261,E226,E227,W291,E303,E731,E305
+ignore = W391,W293,E302,E261,E226,E227,W291,E303,E731,E305,E741
 


### PR DESCRIPTION
Cherry-picked from import_plugin_fuzzy_date_bind branch (#493) to have only the new Fuzzy Date ImportBindPlugin

Checks for a split amount match with transactions from 4 days before until 4 days after.
Base confidence (weight) is set to 0.75 so we can improve with additional description matching, etc.
In case of importing older data one might want to set DELTA_T to a higher value than 4, e.g. 5, 6 or even 7, due to longer banking delays back in the days.